### PR TITLE
build(deps): Dependabot batch — jacoco, @types/react-bootstrap, drop ora/wrap-ansi

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -275,7 +275,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.14</version>
+				<version>0.8.15</version>
 				<executions>
 					<execution>
 						<goals>

--- a/docs/UPGRADE_PLAN.md
+++ b/docs/UPGRADE_PLAN.md
@@ -315,3 +315,38 @@ Rule: **fix errors, flag warnings.** Never edit a test to make a real failure pa
 | Auth change breaks the SPA login flow | Medium | High | Keep `/api/auth` contract; UI smoke + manual E2E in Phase 3 |
 | Java 25 toolchain gaps (Lombok/plugins) | Low–Med | Medium | Intermediate Java 21 stop; bump toolchain versions |
 | Scope creep / re-adding infra "to be safe" | Medium | Medium | Explicit YAGNI rule; infra returns only on real deploy need |
+
+---
+
+## 10. Dependabot follow-ups (deferred majors — opened 2026-06-08)
+
+Batch reviewed 2026-06-08. Merged: jacoco `0.8.15` (patch), `@types/react-bootstrap` `1.1.0`;
+removed orphaned direct deps `ora` + `wrap-ansi`. The two below are **held** — each needs
+its own focused change, not a deps bump.
+
+### 10.1 TypeScript 5.9 → 6.0 (held — PR #211)
+TS6 builds but its stricter inference turns ~17 latent type issues into hard errors
+(`npm run lint`). Fix these in a dedicated branch, then bump:
+- `tsconfig.json` deprecations (hard errors in TS6, removed entirely in TS7): migrate
+  `target: es5 → es2018` (matches the ECMA2018+ FE standard; babel-loader does the real
+  transpile, so tsc target is type-check-only), `moduleResolution: node → "bundler"`
+  (webpack project), and drop `baseUrl` (rewrite `paths` to `./src/*`-relative — verify
+  `tsconfig-paths-webpack-plugin` still resolves the `@components/@common/@pages/@api`
+  aliases). Short-term escape hatch only: `"ignoreDeprecations": "6.0"`.
+- Real type errors to fix: `index.tsx:10` (`getElementById` `HTMLElement | null` → guard
+  or `!`), `Login.tsx:5` (`TS2882` side-effect `.scss` import → add `declare module '*.scss'`
+  ambient decl), `Form.tsx`/`Table.tsx` (`null`/`undefined` strictness on `routes.*.path`
+  and DTO arrays), and the Playwright `tests/` specs (`string | undefined` env args).
+- Escalation: touches `tests/` auth specs → run the full suite per CLAUDE.md.
+
+### 10.2 Remove `@types/react-bootstrap` entirely (follow-up to PR #207)
+Bumped to `1.1.0`, which npm flags as a **stub**: *"react-bootstrap provides its own type
+definitions, so you do not need this installed."* We use react-bootstrap v2 (ships its own
+types), so this `@types` package is vestigial. Next step: delete the `@types/react-bootstrap`
+dependency, `npm install --legacy-peer-deps`, and confirm `npm run lint` (tsc) still passes
+on the 12 `from 'react-bootstrap'` import sites.
+
+### 10.3 react-i18next 15 → 17 (held — PR #209)
+v17 peer-requires `i18next >= 26.2.0`; we're on i18next `24`. Merging alone breaks the peer
+tree. Do as **one coupled major upgrade** (i18next 24 → 26 **+** react-i18next 15 → 17),
+check `storybook-react-i18next` compatibility, then full verify.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@openapitools/openapi-generator-cli": "^2.20.2",
         "@types/lodash": "^4.17.16",
         "@types/react": "^19.2.0",
-        "@types/react-bootstrap": "^0.32.37",
+        "@types/react-bootstrap": "^1.1.0",
         "@types/react-dom": "^19.2.0",
         "@types/react-router-dom": "^5.3.3",
         "ansi-escapes": "^7.0.0",
@@ -33,7 +33,6 @@
         "log-symbols": "^7.0.0",
         "lru-cache": "^11.0.2",
         "minipass": "^7.1.2",
-        "ora": "^8.2.0",
         "path-to-regexp": "^8.4.0",
         "react": "^19.2.0",
         "react-bootstrap": "^2.10.9",
@@ -50,7 +49,6 @@
         "type-fest": "^5.7.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-url": "^14.1.1",
-        "wrap-ansi": "^9.0.0",
         "yup": "^1.6.1"
       },
       "devDependencies": {
@@ -6107,12 +6105,13 @@
       }
     },
     "node_modules/@types/react-bootstrap": {
-      "version": "0.32.37",
-      "resolved": "https://registry.npmjs.org/@types/react-bootstrap/-/react-bootstrap-0.32.37.tgz",
-      "integrity": "sha512-CVHj++uxsj1pRnM3RQ/NAXcWj+JwJZ3MqQ28sS1OQUD1sI2gRlbeAjRT+ak2nuwL+CY+gtnIsMaIDq0RNfN0PA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-bootstrap/-/react-bootstrap-1.1.0.tgz",
+      "integrity": "sha512-n8qsRzcODi1rGmodQQagjSddkvxBRQrU6P/Ec8pUjLuY1cYnYvIAkV4Xp/Ji78t4nhdT7kdMW/MnKEwfrUGasw==",
+      "deprecated": "This is a stub types definition. react-bootstrap provides its own type definitions, so you do not need this installed.",
       "license": "MIT",
       "dependencies": {
-        "@types/react": "*"
+        "react-bootstrap": "*"
       }
     },
     "node_modules/@types/react-datepicker": {
@@ -8025,21 +8024,6 @@
       },
       "engines": {
         "node": ">= 10.0"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-spinners": {
@@ -11841,18 +11825,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -12669,18 +12641,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-function": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -13190,21 +13150,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/open": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
@@ -13249,96 +13194,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/ora": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^2.9.2",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.0.0",
-        "log-symbols": "^6.0.0",
-        "stdin-discarder": "^0.2.2",
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/log-symbols": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.3.0",
-        "is-unicode-supported": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/log-symbols/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/own-keys": {
@@ -14837,22 +14692,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -15612,18 +15451,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stdin-discarder": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -17781,62 +17608,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -57,7 +57,7 @@
     "@openapitools/openapi-generator-cli": "^2.20.2",
     "@types/lodash": "^4.17.16",
     "@types/react": "^19.2.0",
-    "@types/react-bootstrap": "^0.32.37",
+    "@types/react-bootstrap": "^1.1.0",
     "@types/react-dom": "^19.2.0",
     "@types/react-router-dom": "^5.3.3",
     "ansi-escapes": "^7.0.0",
@@ -78,7 +78,6 @@
     "log-symbols": "^7.0.0",
     "lru-cache": "^11.0.2",
     "minipass": "^7.1.2",
-    "ora": "^8.2.0",
     "path-to-regexp": "^8.4.0",
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.9",
@@ -95,7 +94,6 @@
     "type-fest": "^5.7.0",
     "webidl-conversions": "^7.0.0",
     "whatwg-url": "^14.1.1",
-    "wrap-ansi": "^9.0.0",
     "yup": "^1.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Consolidated review of the 6 open Dependabot PRs (opened 2026-06-08). Minor/patch applied; majors triaged.

## Applied
| Source PR | Change | Why |
|-----------|--------|-----|
| #206 | `jacoco-maven-plugin` 0.8.14 → **0.8.15** | patch, safe |
| #207 | `@types/react-bootstrap` 0.32.37 → **1.1.0** | npm flags it a stub ("react-bootstrap provides its own types") — full removal tracked as follow-up |
| #210 | **removed** `ora` | orphaned direct dep — no consumers, unused in app/lint |
| #208 | **removed** `wrap-ansi` | orphaned direct dep — real consumers ship nested 6.x/7.x |

Dropping the two orphans removed **16 transitive packages** (lockfile −231 lines).

## Held (left open as tracked follow-ups — see `docs/UPGRADE_PLAN.md §10`)
- **#211 typescript 6.0** — builds, but stricter inference surfaces ~17 latent `tsc` errors + 3 `tsconfig` deprecations. Needs a dedicated migration branch.
- **#209 react-i18next 17** — peer-requires `i18next >= 26.2.0`; we're on 24. Must be a coupled i18next 24→26 + react-i18next 15→17 upgrade.

## Verification (all green)
- `./mvnw clean verify` — BUILD SUCCESS, 7 unit + 13 IT, jacoco 0.8.15
- `npm run lint` — pass (tsc 5.9.3 + eslint)
- `npm run smoke` — 1 passed, no console errors
- Lockfile tripwire: `grep -c tfs-app1 package-lock.json` → 0

Closes #206, #207, #208, #210.