### PR TITLE
fix(auth): register CORS in Spring Security chain so cross-origin logout works (+ un-skip logout E2E)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,7 +81,7 @@ the source. Before any non-demo deployment, every one of these must be revisited
 | Caveat | Location | Reason | Required before deploy |
 | ------ | -------- | ------ | ---------------------- |
 | **CSRF disabled** | `api/.../auth/SecurityConfig.java` | Same-origin SPA + JSON API in a local demo with no real data | Re-enable; emit + check CSRF token on state-changing endpoints |
-| **CORS permissive** (`allowedOriginPatterns: "*"` + `allowCredentials: true`) | `api/.../infrastructure/web/WebConfiguration.java` | Allow the local dev SPA to call the API | Lock down to known origins per environment |
+| **CORS permissive** (`allowedOriginPatterns: "*"` + `allowCredentials: true`) | `api/.../auth/SecurityConfig.java` (`corsConfigurationSource` bean, registered in the security filter chain via `.cors(...)`) | Allow the local dev SPA (`:8080`) to call the API (`:8082`), incl. preflight to authenticated endpoints like logout | Lock down to known origins per environment |
 | **Bootstrap user `admin` / `admin`** seeded via Flyway `V3` | `api/src/main/resources/db/migration/V3__seed_admin_user.sql` | One-step local login | Remove the seed migration; provision real users out-of-band |
 | **H2 console exposed** at `/h2-console` with `sameOrigin` frame options, no auth | `api/.../auth/SecurityConfig.java` (`PUBLIC_PATHS`) | Local DB inspection during development | Drop `/h2-console` from `PUBLIC_PATHS`; or strip the dependency entirely on the prod profile |
 | **All `/actuator/**` endpoints public** | `api/.../auth/SecurityConfig.java` (`PUBLIC_PATHS`) | Easy metrics/health access locally | Restrict to authenticated roles or a management port; expose only `health` publicly |

--- a/api/src/main/java/sk/foundation/techdemo/auth/SecurityConfig.java
+++ b/api/src/main/java/sk/foundation/techdemo/auth/SecurityConfig.java
@@ -1,9 +1,12 @@
 package sk.foundation.techdemo.auth;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -12,6 +15,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 /**
  * Simple session-based security for the local demo.
@@ -43,9 +49,33 @@ public class SecurityConfig {
 		return configuration.getAuthenticationManager();
 	}
 
+	/**
+	 * Permissive CORS for the local SPA dev server (origin :8080 calling the API on :8082).
+	 * allowCredentials is required so the session cookie flows; with credentials the spec forbids
+	 * "*" for origins, so we use origin patterns. Demo-only — tighten allowed origins for any real
+	 * deployment (tracked as a demo-mode caveat in SECURITY.md).
+	 */
+	@Bean
+	public CorsConfigurationSource corsConfigurationSource() {
+		CorsConfiguration config = new CorsConfiguration();
+		config.setAllowedOriginPatterns(List.of("*"));
+		config.setAllowedMethods(List.of("*"));
+		config.setAllowedHeaders(List.of("*"));
+		config.setAllowCredentials(true);
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", config);
+		return source;
+	}
+
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 		http
+				// Register CORS in the security filter chain so preflight OPTIONS requests are
+				// handled (and short-circuited) BEFORE authorization. Without this, a credential-less
+				// preflight to an authenticated endpoint (e.g. POST /api/auth/logout) hits
+				// .anyRequest().authenticated() and 401s, so the browser blocks the real request.
+				// Uses the corsConfigurationSource() bean below.
+				.cors(Customizer.withDefaults())
 				// SECURITY: CSRF deliberately disabled for the local demo (JSON API + same-origin SPA,
 				// no production data). Tracked as a demo-mode caveat in SECURITY.md; must be re-enabled
 				// before any real deployment (CSRF token endpoint + header check on state-changing

--- a/api/src/main/java/sk/foundation/techdemo/infrastructure/web/WebConfiguration.java
+++ b/api/src/main/java/sk/foundation/techdemo/infrastructure/web/WebConfiguration.java
@@ -2,7 +2,6 @@ package sk.foundation.techdemo.infrastructure.web;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.resource.PathResourceResolver;
@@ -12,16 +11,9 @@ import java.io.IOException;
 @Configuration
 public class WebConfiguration implements WebMvcConfigurer {
 
-	@Override
-	public void addCorsMappings(CorsRegistry registry) {
-		// Permissive CORS for the local SPA dev server. allowCredentials is required so the
-		// session cookie flows; with credentials we must use origin patterns, not "*".
-		// Demo-only — tighten the allowed origins for any real deployment.
-		registry.addMapping("/**")
-				.allowedOriginPatterns("*")
-				.allowedMethods("*")
-				.allowCredentials(true);
-	}
+	// CORS is configured in SecurityConfig#corsConfigurationSource and registered in the security
+	// filter chain (.cors(...)), so preflight is handled before authorization. Do not also define
+	// addCorsMappings here — the security-chain CORS is the single source of truth.
 
 	@Override
 	public void addResourceHandlers(ResourceHandlerRegistry registry) {

--- a/ui/src/components/header/AppHeader.tsx
+++ b/ui/src/components/header/AppHeader.tsx
@@ -41,6 +41,7 @@ const AppHeader = () => {
                                     </div>
                                     <span>{' | '}</span>
                                     <button
+                                        id="app_header_logout"
                                         onClick={onLogoutSuccess}
                                         className="ms-2">
                                         {t('common.btn.logout')}

--- a/ui/tests/test_authentication.spec.ts
+++ b/ui/tests/test_authentication.spec.ts
@@ -67,10 +67,9 @@ test.describe('On login page', () => {
         await expect(headerUsername).toContainText(USER_FULLNAME)
     })
 
-    // this terminates session for other tests !!!!
-    // we need a second user to be able to run this !!!!
-    // skip this test for now
-    test.skip('Successfully Logged out', async ({ page }) => {
+    // Each test runs in its own isolated browser context (no shared global session since
+    // global_setup was removed), so logging out here no longer affects other tests.
+    test('Successfully Logged out', async ({ page }) => {
         await page.goto(BASE_URL)
 
         //check
@@ -88,13 +87,15 @@ test.describe('On login page', () => {
         await inputPassword.fill(PASSWORD)
         await btnSubmit.click()
 
-        // find elements
-        const btnOdhlasit = page.locator('button.ms-2')
+        // logged in: land on home, header shows the user
+        await expect(page).toHaveURL(BASE_URL)
+        await expect(page.locator('#app_header_user_fullname')).toContainText(USER_FULLNAME)
 
-        // interact
-        await btnOdhlasit.click()
+        // interact — log out (stable id, not a bootstrap utility class)
+        await page.locator('#app_header_logout').click()
 
-        // find elements
+        // check — logout redirects back to /login and the header reflects the signed-out state
+        await expect(page).toHaveURL(BASE_URL + '/login')
         const headerUsername = page.locator('#app_header_user_fullname')
 
         // check


### PR DESCRIPTION
## The bug
Cross-origin **logout** (SPA `:8080` → API `:8082`) was silently broken. The `Successfully Logged out` E2E was `test.skip`ped, which masked it.

- CORS was configured **only at the MVC level** (`WebConfiguration#addCorsMappings`), which runs **after** the Spring Security filter chain.
- A CORS **preflight `OPTIONS` carries no cookie**, so it hit `.anyRequest().authenticated()` → **401 before MVC CORS ran** → browser blocked the real `POST /api/auth/logout` → `AuthProvider.logout`'s `await` threw and was swallowed by its `catch` → the SPA stayed logged in.
- **Login worked** only because `/api/auth/login` is a `permitAll` path; logout was the first *authenticated* cross-origin request in the flow.

## The fix
- `SecurityConfig`: register `.cors(Customizer.withDefaults())` in the chain + a `CorsConfigurationSource` `@Bean` (mirrors the existing demo-permissive config). Preflight is now handled **before** authorization.
- `WebConfiguration`: removed the now-redundant `addCorsMappings` (single source of truth = the security-chain bean).
- Demo CORS **posture is unchanged** (still permissive origin-patterns + credentials; tighten before prod per `SECURITY.md`).

## Test
- **Un-skipped** `Successfully Logged out`. Its original *"terminates session for other tests"* reason died with `global_setup.ts` — tests now run in isolated contexts (proven: the other 2 pass alongside it).
- **Hardened**: stable `#app_header_logout` id (was the brittle `button.ms-2`), and assert the post-logout redirect to `/login` in addition to the header text.
- Added `id="app_header_logout"` to the logout button.

## Verification
- `./mvnw clean verify` — BUILD SUCCESS, 7 unit + 13 IT, Checkstyle clean
- `cd ui && npm run lint` — clean
- `npm run playwright` — **3/3 green** (was 2 passed / 1 failed before the fix; 1 skipped before that)